### PR TITLE
Fix favicon manifest paths

### DIFF
--- a/images/favicon/site.webmanifest
+++ b/images/favicon/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"","short_name":"","icons":[{"src":"android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}


### PR DESCRIPTION
## Summary
- update the favicon paths to remove leading slashes

## Testing
- `tail -c1 images/favicon/site.webmanifest | od -An -t x1`

------
https://chatgpt.com/codex/tasks/task_e_683a69d3fb50832991f0cecf8f0fbcc7